### PR TITLE
Fix detection of latex brewfile

### DIFF
--- a/bin/virus.py
+++ b/bin/virus.py
@@ -90,7 +90,7 @@ for groupname, brewfile in selected_brewfiles.items():
     subprocess.run(['brew', 'bundle', 'install', '--file', brewfile_path])
     LOG.info('Finished installing %s dependencies!', groupname)
 
-if 'latex.Brewfile' in selected_brewfiles:
+if 'latex' in selected_brewfiles:
     LOG.info('LaTeX option selected; installing digestif.')
     subprocess.run(
         ['sh', str(pathlib.Path(__file__).parent / 'install-digestif.sh')]


### PR DESCRIPTION
## Summary
- fix detection of LaTeX brew group in `virus.py`

## Testing
- `python3 -m py_compile bin/virus.py`
- `python3 -m py_compile .config/afew/hey-filter.py .config/goimapnotify/converter.py bin/virus.py`
