### PR TITLE
Fix virus directory creation with home path

### DIFF
--- a/bin/virus.py
+++ b/bin/virus.py
@@ -133,20 +133,20 @@ subprocess.run(
 )
 
 LOG.info('Linking doom (so topgrade can find it)')
+emacs_bin = pathlib.Path.home() / '.config' / 'emacs' / 'bin'
 subprocess.run(
     [
         'mkdir',
-        # '~/.emacs.d/bin',
-        '~/.config/emacs/bin',
+        '-p',
+        str(emacs_bin),
     ]
 )
 subprocess.run(
     [
         'ln',
         '-svf',
-        '~/.config/doom-emacs/bin/doom',
-        # '~/.emacs.d/bin/doom',
-        '~/.config/emacs/bin/doom',
+        str(pathlib.Path.home() / '.config' / 'doom-emacs' / 'bin' / 'doom'),
+        str(emacs_bin / 'doom'),
     ]
 )
 


### PR DESCRIPTION
## Summary
- ensure emacs bin directory is created inside the user home

## Testing
- `python3 -m py_compile bin/virus.py`