### PR TITLE
Fix osxdefaults WiFi mention

### DIFF
--- a/bin/osxdefaults.sh
+++ b/bin/osxdefaults.sh
@@ -63,7 +63,7 @@ defaults write org.herf.Flux locationType L
 ## set wake time to 7am
 defaults write org.herf.Flux wakeTime 420
 
-# bluetooth and sound in menu bar
+# bluetooth, sound, and WiFi in menu bar
 # defaults write com.apple.controlcenter "NSStatusItem Visible Bluetooth" -bool false
 defaults write com.apple.controlcenter "NSStatusItem Visible Sound" -bool true
 defaults write com.apple.controlcenter "NSStatusItem Visible WiFi" -bool false


### PR DESCRIPTION
## Summary
- update a comment in `bin/osxdefaults.sh` so it lists bluetooth, sound, **and** WiFi

## Testing
- `grep -n "WiFi" -n bin/osxdefaults.sh`