### PR TITLE
Document macOS goimapnotify scripts

### DIFF
--- a/.config/goimapnotify/README.md
+++ b/.config/goimapnotify/README.md
@@ -1,33 +1,14 @@
 # goimapnotify on macOS
 
 This directory holds configuration and helper scripts for running
-[goimapnotify](https://github.com/videolabs/goimapnotify) as a macOS
+[goimapnotify](https://gitlab.com/shackra/goimapnotify) as a macOS
 *LaunchAgent* for various mailboxes.
 
-Each mailbox has its own folder (e.g. `human-signal`, `kelleys`,
+Each mailbox has its own folder (e.g. `kelleys`,
 `protonmail`) containing a `daemon-template.plist` and a
 `notify.conf`. The template is used to generate the plist that
 `launchctl` loads while `notify.conf` is passed directly to
 `goimapnotify`.
-
-## Helper scripts
-
-- `install-mailbox-daemon.sh` – Create and load a LaunchAgent for a
-  mailbox. It requires the mailbox name and the mail provider which
-determines the script used to sync mail.
-- `uninstall-mailbox-daemon.sh` – Unload and remove the LaunchAgent for
-a mailbox.
-- `restart-mailbox-daemon.sh` – Rotate log files and restart the
-  LaunchAgent via `launchctl kickstart`.
-- `run-gmail-sync.sh` – Called by Gmail based LaunchAgents. Runs `gmi
-  sync` for the mailbox then launches `goimapnotify` with the mailbox
-  configuration.
-- `run-protonmail-sync.sh` – Similar to `run-gmail-sync.sh` but uses
-  `mbsync` and fetches credentials through gpg for ProtonMail.
-- `cron.sh` – Example cron script that syncs gmail accounts and runs
-  `notmuch new`.
-
-Log output for each mailbox is written to `/tmp/com.user.goimapnotify-<mailbox>.{out,err}`.
 
 ## Installing a LaunchAgent
 
@@ -37,22 +18,40 @@ Configure the mailbox directory as needed and then run, for example:
 ./install-mailbox-daemon.sh --mailbox=kelleys --provider=gmail
 ```
 
+`install-mailbox-daemon.sh` creates and loads a LaunchAgent for a
+  mailbox. It requires the mailbox name and the mail provider which
+determines the script used to sync mail.
+
 The script places the generated plist in
 `~/Library/LaunchAgents/` and loads it with `launchctl`.
 
 ## Managing services
 
-Restart a running service:
+### Restart a running service:
 
 ```sh
 ./restart-mailbox-daemon.sh --mailbox=kelleys
 ```
 
-Remove the LaunchAgent entirely:
+`restart-mailbox-daemon.sh` rotates log files and restarts the
+  LaunchAgent via `launchctl kickstart`.
+
+### Remove the LaunchAgent entirely:
 
 ```sh
 ./uninstall-mailbox-daemon.sh --mailbox=kelleys
 ```
+
+`uninstall-mailbox-daemon.sh` unloads and removes the LaunchAgent for
+a mailbox.
+
+### Debugging
+
+### Logs
+
+Log output for each mailbox is written to `/tmp/com.user.goimapnotify-<mailbox>.{out,err}`.
+
+### Running Manually
 
 The provider scripts can also be run manually for testing:
 
@@ -60,5 +59,13 @@ The provider scripts can also be run manually for testing:
 ./run-gmail-sync.sh --mailbox=kelleys
 ./run-protonmail-sync.sh --mailbox=protonmail
 ```
+
+`run-gmail-sync.sh` is called by Gmail based LaunchAgents. It runs `gmi
+sync` for the mailbox then launches `goimapnotify` with the mailbox
+configuration.
+
+`run-protonmail-sync.sh` is similar to `run-gmail-sync.sh` but uses
+`mbsync` and fetches credentials through age for ProtonMail (mail 
+is synced using ProtonMail's Bridge).
 
 

--- a/.config/goimapnotify/README.md
+++ b/.config/goimapnotify/README.md
@@ -1,15 +1,64 @@
-# Installation
+# goimapnotify on macOS
 
-Still need to automate this... for now, you'll need to:
+This directory holds configuration and helper scripts for running
+[goimapnotify](https://github.com/videolabs/goimapnotify) as a macOS
+*LaunchAgent* for various mailboxes.
 
-- move the launch agent using:
+Each mailbox has its own folder (e.g. `human-signal`, `kelleys`,
+`protonmail`) containing a `daemon-template.plist` and a
+`notify.conf`. The template is used to generate the plist that
+`launchctl` loads while `notify.conf` is passed directly to
+`goimapnotify`.
+
+## Helper scripts
+
+- `install-mailbox-daemon.sh` – Create and load a LaunchAgent for a
+  mailbox. It requires the mailbox name and the mail provider which
+determines the script used to sync mail.
+- `uninstall-mailbox-daemon.sh` – Unload and remove the LaunchAgent for
+a mailbox.
+- `restart-mailbox-daemon.sh` – Rotate log files and restart the
+  LaunchAgent via `launchctl kickstart`.
+- `run-gmail-sync.sh` – Called by Gmail based LaunchAgents. Runs `gmi
+  sync` for the mailbox then launches `goimapnotify` with the mailbox
+  configuration.
+- `run-protonmail-sync.sh` – Similar to `run-gmail-sync.sh` but uses
+  `mbsync` and fetches credentials through gpg for ProtonMail.
+- `cron.sh` – Example cron script that syncs gmail accounts and runs
+  `notmuch new`.
+
+Log output for each mailbox is written to `/tmp/com.user.goimapnotify-<mailbox>.{out,err}`.
+
+## Installing a LaunchAgent
+
+Configure the mailbox directory as needed and then run, for example:
 
 ```sh
-cp ~/.config/goimapnotify/com.pakelley.imapnotify.plist ~/Library/LaunchAgents
+./install-mailbox-daemon.sh --mailbox=kelleys --provider=gmail
 ```
 
-- load the agent
+The script places the generated plist in
+`~/Library/LaunchAgents/` and loads it with `launchctl`.
+
+## Managing services
+
+Restart a running service:
 
 ```sh
-launchctl load -w ~/Library/LaunchAgents/com.pakelley.goimapnotify.plist
+./restart-mailbox-daemon.sh --mailbox=kelleys
 ```
+
+Remove the LaunchAgent entirely:
+
+```sh
+./uninstall-mailbox-daemon.sh --mailbox=kelleys
+```
+
+The provider scripts can also be run manually for testing:
+
+```sh
+./run-gmail-sync.sh --mailbox=kelleys
+./run-protonmail-sync.sh --mailbox=protonmail
+```
+
+


### PR DESCRIPTION
## Summary
- document each helper script under `.config/goimapnotify`
- explain how to install, restart, and uninstall LaunchAgents
- note provider run scripts and cron example

## Testing
- `true`